### PR TITLE
fixing PEP 508 failure while parsing pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kaytool"
 description ="KayTool boosts ComfyUI workflow efficiency with powerful tools like: image processing (resize, color, blur, expand, merge, crop), background/mask tasks via BiRefNet/RemBG, wireless data transfer (Set&Get), AI translation (Tencent/Baidu), Professional high-precision resource monitoring, dynamic math operations, flexible text handling, precision sliders, metadata/color profile-supported image saving, batch processing via folder loading, canvas node map export as PNG with metadata, quick Run options via right-click, node alignment toolbar with custom styles, and custom ComfyUI logo integration."
 version = "0.70.13"
 license = {file = "LICENSE"}
-dependencies = ["rembg, timm, opencv-python, py-cpuinfo, pynvml"]
+dependencies = ["rembg", "timm", "opencv-python", "py-cpuinfo", "pynvml"]
 
 [project.urls]
 Repository = "https://github.com/kk8bit/KayTool"


### PR DESCRIPTION
Multiple packages were mentioned into a single string which is not PEP 508 compliant and caused failure during installation of dependencies using [uv](https://github.com/astral-sh/uv)

