### PR TITLE
fix: correct image source path and enhance error handling for image loading

### DIFF
--- a/web/gululu.js
+++ b/web/gululu.js
@@ -13,7 +13,7 @@ const KayGuLuLuManager = {
     pixelCanvas: null,
     pixelCtx: null,
     pixelDataCache: null,
-    imgSrc: "/extensions/kaytool/resources/GuLuLu.gif",
+    imgSrc: "/extensions/KayTool/resources/GuLuLu.gif",
     effectiveBounds: null,
     isAnimating: false,
     animationTimer: null,
@@ -113,6 +113,10 @@ const KayGuLuLuManager = {
             img.onload = () => {
                 this.updatePixelDataCache();
                 this.updatePosition();
+            };
+            img.onerror = () => {
+                console.warn("KayTool: GuLuLu image failed to load", img.src);
+                this.pixelDataCache = null;
             };
             this.container.appendChild(img);
             document.body.appendChild(this.container);
@@ -251,13 +255,25 @@ const KayGuLuLuManager = {
         if (containerRect.width === 0 || containerRect.height === 0) {
             return;
         }
+
+        const img = this.container?.querySelector("img");
+        if (!img || !img.complete || img.naturalWidth === 0) {
+            // Image not ready or failed to load; clear cache and skip
+            this.pixelDataCache = null;
+            return;
+        }
+
         this.pixelCanvas.width = containerRect.width;
         this.pixelCanvas.height = containerRect.height;
         this.pixelCtx.clearRect(0, 0, this.pixelCanvas.width, this.pixelCanvas.height);
-        this.pixelCtx.drawImage(this.container.querySelector("img"), 0, 0, containerRect.width, containerRect.height);
-        this.pixelDataCache = this.pixelCtx.getImageData(0, 0, this.pixelCanvas.width, this.pixelCanvas.height);
-
-        this.calculateEffectiveBounds();
+        try {
+            this.pixelCtx.drawImage(img, 0, 0, containerRect.width, containerRect.height);
+            this.pixelDataCache = this.pixelCtx.getImageData(0, 0, this.pixelCanvas.width, this.pixelCanvas.height);
+            this.calculateEffectiveBounds();
+        } catch (e) {
+            console.warn("KayTool: failed to update pixel data cache", e);
+            this.pixelDataCache = null;
+        }
     },
 
     calculateEffectiveBounds() {


### PR DESCRIPTION
PR summary
- Fix resource path casing and harden GuLuLu image handling in `web/gululu.js` to prevent runtime errors when the image is missing or not yet loaded.

What changed
- Corrected image source path casing:
  - "/extensions/kaytool/resources/GuLuLu.gif" -> "/extensions/KayTool/resources/GuLuLu.gif"
- Added image load error handler:
  - Logs a warning and clears `pixelDataCache` on `img.onerror`.
- Added readiness checks before drawing:
  - Skip drawing and clear cache if image is not present, not complete, or has zero natural width.
- Wrapped drawImage/getImageData in try/catch:
  - Logs a warning and clears `pixelDataCache` on failure to avoid uncaught exceptions.
- Minor: ensured newline at end of file.

Motivation
- Prevents uncaught exceptions from `drawImage`/`getImageData` when the image fails to load or is not ready.
- Fixes a casing bug that can break resource lookup on case-sensitive filesystems/servers.
- Improves stability and logging so failures are observable without breaking the UI.

Testing / QA steps
1. Load the app and confirm GuLuLu renders and animates when the GIF is present.
2. Rename or remove `web/resources/GuLuLu.gif` to simulate a missing resource; confirm:
   - No uncaught exceptions in console.
   - A console warning "KayTool: GuLuLu image failed to load" appears.
   - No visual crashes; `pixelDataCache` is cleared.
3. Resize the window/container and verify no errors occur and behavior remains correct when the image is available.
4. Verify the extension folder name is `KayTool` (capitalization) on the deployment environment.
